### PR TITLE
Allow any MIDI controller

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -54,9 +54,7 @@ function onMidiSuccess(result) {
   let deviceCount = 0;
 
   for (let device of result.inputs.values()) {
-    if (device.name === `LKMK3 MIDI`) {
-      device.addEventListener(`midimessage`, getMIDIMessage);
-    }
+    device.addEventListener(`midimessage`, getMIDIMessage);
     deviceCount++;
   }
   if (deviceCount > 0) {


### PR DESCRIPTION
Commit e2e6963bf3b56038b29ee616719ed919f08dee84 added a condition that makes the code only accept one specific MIDI controller. However, the tool is certainly able to be used with any MIDI input, regardless of the name.

Commit created directly on the GitHub web interface.